### PR TITLE
Use simple_tag instead of assignment_tag

### DIFF
--- a/social_widgets/templatetags/social_widgets.py
+++ b/social_widgets/templatetags/social_widgets.py
@@ -159,7 +159,7 @@ def social_widget_render(parser, token):
     return SocialWidgetNode(args, kwargs)
 
 
-@register.assignment_tag
+@register.simple_tag
 def social_get_facebook_locale(locale):
     """
      Normalize the locale string and split the value needed for the api url


### PR DESCRIPTION
The assignment_tag is deprecated in Django 1.9.

refs https://docs.djangoproject.com/en/2.2/releases/1.9/#assignment-tag